### PR TITLE
fix: 修复 5sing newget 接口 JSON 字段映射错误

### DIFF
--- a/fivesing/fivesing.go
+++ b/fivesing/fivesing.go
@@ -443,15 +443,17 @@ func (f *Fivesing) fetchSongInfo(songID, songType string) (*model.Song, error) {
 	if metaBody != nil {
 		var metaResp struct {
 			Data struct {
-				SongName string `json:"songName"`
-				Singer   string `json:"singer"`
-				Img      string `json:"img"`
+				SN   string `json:"SN"`
+				User struct {
+					NN string `json:"NN"`
+					I  string `json:"I"`
+				} `json:"user"`
 			} `json:"data"`
 		}
 		if json.Unmarshal(metaBody, &metaResp) == nil {
-			name = metaResp.Data.SongName
-			artist = metaResp.Data.Singer
-			cover = metaResp.Data.Img
+			name = metaResp.Data.SN
+			artist = metaResp.Data.User.NN
+			cover = metaResp.Data.User.I
 		}
 	}
 


### PR DESCRIPTION
`fetchSongInfo` 解析 `/song/newget` 接口时使用了错误的 JSON tag（`songName`、`singer`、`img`），实际接口返回的字段名为 `SN`、`user.NN`、`user.I`。

导致通过 `Parse()` 获取歌曲信息时，歌名、歌手、封面始终为空，歌名只能走兜底逻辑返回 `5sing_{type}_{id}`。

实际接口返回结构：

```json
{
  "data": {
    "SN": "小苹果",
    "user": {
      "NN": "tutuhaoshuaio",
      "I": "https://5sstatic.kugou.com/images/nan.jpg"
    }
  }
}